### PR TITLE
feat(opponent): add endpoints to list predefined opponents

### DIFF
--- a/Controllers/OpponentsController.cs
+++ b/Controllers/OpponentsController.cs
@@ -1,0 +1,30 @@
+namespace PokemonBattleApi.Controllers;
+
+using Microsoft.AspNetCore.Mvc;
+using PokemonBattleApi.Models;
+using PokemonBattleApi.Services;
+
+
+[ApiController]
+[Route("api/[controller]")]
+public class OpponentsController : ControllerBase
+{
+    private readonly OpponentService _opponentService = new();
+
+    [HttpGet]
+    public ActionResult<List<Opponent>> GetAllOpponents()
+    {
+        var opponents = _opponentService.GetAllOpponents();
+        return Ok(opponents);
+    }
+
+    [HttpGet("{id}")]
+    public ActionResult<Opponent> GetOpponentById(int id)
+    {
+        var opponent = _opponentService.GetOpponentById(id);
+        if (opponent == null)
+            return NotFound($"Opponent with ID {id} not found.");
+
+        return Ok(opponent);
+    }
+}

--- a/Services/OpponentService.cs
+++ b/Services/OpponentService.cs
@@ -1,0 +1,17 @@
+using PokemonBattleApi.Data;
+using PokemonBattleApi.Models;
+
+namespace PokemonBattleApi.Services;
+
+public class OpponentService
+{
+    public List<Opponent> GetAllOpponents()
+    {
+        return PredefinedOpponents.Opponents;
+    }
+
+    public Opponent? GetOpponentById(int id)
+    {
+        return PredefinedOpponents.Opponents.FirstOrDefault(o => o.Id == id);
+    }
+}


### PR DESCRIPTION
Added support for retrieving predefined opponents through the API. Introduced OpponentController and OpponentService to expose a list of opponents and allow querying by ID. Useful for enabling battles against fixed enemy teams.